### PR TITLE
time fix, canvasmodulate on death  fix

### DIFF
--- a/Scripts/Overlay.cs
+++ b/Scripts/Overlay.cs
@@ -41,8 +41,17 @@ public partial class Overlay : CanvasLayer
 
     public override void _Process(double delta)
     {
-        time = time + delta;
-        Stopwatch.Text = "Time:" + Math.Round(time, 2).ToString();
+        if (!GetTree().Paused)
+        {
+            time = time + delta;
+            Stopwatch.Text = "Time:" + Math.Round(time, 2).ToString();
+        }
+        else
+        {
+            time = 0;
+            Stopwatch.Text = "Time:" + Math.Round(time, 2).ToString();
+        }
+
         if (isinit == false)
         {
             darken();

--- a/Scripts/Player.cs
+++ b/Scripts/Player.cs
@@ -648,6 +648,7 @@ public partial class Player : GenericCharacterClass
 	public void player_killed()
 	{
 		Losing_sfx.Play();
+		canvmod.Color = new Color(0.00f, 0.00f, 0.00f);
 		GetTree().Paused = true;
 	}
 


### PR DESCRIPTION
time now only starts when game not in main menu and the canvasmodulate is now black again when the player dies (==>no indirect lighting)